### PR TITLE
Remove setuptools library

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -5,7 +5,6 @@ RUN apt-get -y update && apt-get -y install libxml2-dev
 RUN /usr/local/bin/python -m pip install --upgrade pip
 RUN pip install robotframework
 RUN pip install robotframework-selenium2library
-RUN pip install setuptools
 RUN pip install RESTinstance
 
 VOLUME /tests


### PR DESCRIPTION
The library RESTinstance now have a dependency to setuptools in a specific version.