### PR TITLE
Do not use jsonpath_ng version 1.7.0 anymore

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,10 +6,29 @@ The following versions are checked for CRITICAL securitiy issues:
 
 | Version | Supported          |
 | ------- | ------------------ |
+| 1.1.8   | :white_check_mark: |
 | 1.1.7   | :white_check_mark: |
-| 1.1.6   | :x:                |
-| 1.1.5   | :x:                |
-| 1.1.4   | :x:                |
-| 1.1.3   | :x:                |
-| 1.1.2   | :x:                |
-| < 1.1   | :x:                |
+
+## Version 1.1.8
+
+- CVE-2026-8376
+- CVE-2026-42496
+- CVE-2026-7210
+- CVE-2026-42217
+- CVE-2026-42216
+- CVE-2026-24660
+- CVE-2026-24450
+- CVE-2026-20884
+- CVE-2026-42960
+- CVE-2026-33278
+
+## Version 1.1.7
+
+- CVE-2026-7210
+- CVE-2026-42217
+- CVE-2026-42216
+- CVE-2026-24660
+- CVE-2026-24450
+- CVE-2026-20884
+- CVE-2026-42960
+- CVE-2026-33278

--- a/dockerfile
+++ b/dockerfile
@@ -8,7 +8,6 @@ RUN pip install robotframework
 RUN pip install robotframework-selenium2library
 RUN pip install RESTinstance
 RUN /usr/local/bin/python -m pip install robotframework-doctestlibrary
-RUN pip install --force-reinstall -v "jsonpath_ng==1.7.0"
 
 VOLUME /tests
 VOLUME /output


### PR DESCRIPTION
With the latest version of RESTInstance Library jsonpath_ng version 1.8.0 or higher should be used.